### PR TITLE
use sqlite unless there is a GAE env var

### DIFF
--- a/lmnop_project/settings.py
+++ b/lmnop_project/settings.py
@@ -79,17 +79,22 @@ WSGI_APPLICATION = 'lmnop_project.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'lmnop_db',
-        'USER': 'application',
-        'PASSWORD': os.environ['POSTGRE_PW'],
-        'HOST': '/cloudsql/lmnop-295416:us-central1:lmnop-5432',
-        'PORT': 5432
-    },
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    }
 }
         
-if not os.getenv('GAE_INSTANCE'):
-    DATABASES['default']['HOST'] = '127.0.0.1'
+if os.getenv('GAE_INSTANCE'):
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'NAME': 'lmnop_db',
+            'USER' : 'application',
+            'PASSWORD' : os.environ['POSTGRE_PW'],
+            'HOST' : '/cloudsql/lmnop-295416:us-central1:lmnop-5432',
+            'PORT' : 5432
+        }
+    }
 
 
 # Password validation
@@ -128,13 +133,11 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 
+STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'www', 'static')
 
-if os.getenv('GAE_INSTANCE'):
-    GS_STATIC_FILE_BUCKET = 'lmnop-295416.appspot.com'
-    STATIC_URL = f'https://storage.cloud.google.com/{GS_STATIC_FILE_BUCKET}/static/'
-else:
-    STATIC_URL = '/static/'
+GS_STATIC_FILE_BUCKET = 'lmnop-295416.appspot.com'
+STATIC_URL = f'https://storage.cloud.google.com/{GS_STATIC_FILE_BUCKET}/static/'
 
 # Where to send user after successful login, and logout, if no other page is provided.
 LOGIN_REDIRECT_URL = 'my_user_profile'


### PR DESCRIPTION
Should not need postgres to run app locally. This PR sets sqlite as the default db in all cases except when GAE environment variable is set.